### PR TITLE
Fixing a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-1. From XCode, just add a new "Symbol Image Set" in your Assets catalog.
+1. From Xcode, just add a new "Symbol Image Set" in your Assets catalog.
 2. Then import the symbol directly and start to use it.
 
 <img width="1806" alt="Screenshot 2023-02-05 at 18 03 59" src="https://user-images.githubusercontent.com/736246/216836517-91371c18-e8ed-4085-9a26-929a2ee185ca.png">


### PR DESCRIPTION
### Short description

 I fixed a typo of Xcode in README.

I read the document to work with `social-symbols` in my project, and I found the typo.

I'm a big fan of SF Symbols and thank you for this amazing package 🚀

### Reference

https://developer.apple.com/documentation/xcode/